### PR TITLE
Fix for multiple listeners, 3+ arguments

### DIFF
--- a/lib/drip/emitter.js
+++ b/lib/drip/emitter.js
@@ -203,9 +203,9 @@ EventEmitter.prototype.emit = function () {
         fns[i].call(this, arguments[1], arguments[2]);
       } else {
         if (!a) {
-          var l = arguments.length
-          a = Array(l - 1);
-          for (var i2 = 1; i2 < l; i2++) a[i2 - 1] = arguments[i2];
+          var la = arguments.length
+          a = Array(la - 1);
+          for (var i2 = 1; i2 < la; i2++) a[i2 - 1] = arguments[i2];
         }
         fns[i].apply(this, a);
       }

--- a/test/emitter.emit.js
+++ b/test/emitter.emit.js
@@ -55,15 +55,19 @@ describe('emitter', function () {
   });
 
   describe('.emit(\'event\', arg, arg, arg, arg, arg)', function () {
-    it('should trigger listeners with 3+ arguments', function () {
+    it('should trigger multiple listeners with 3+ arguments', function () {
       var emitter = new drip.EventEmitter()
         , listener = chai.spy()
+        , listener2 = chai.spy()
         , noop = chai.spy();
       emitter.on('event', listener);
+      emitter.on('event', listener2);
       emitter.on('noop', noop);
       emitter.emit('event', 1, 2, 'three', 4, 5);
       listener.should.have.been.called.once;
       listener.should.have.always.been.called.with.exactly(1, 2, 'three', 4, 5);
+      listener2.should.have.been.called.once;
+      listener2.should.have.always.been.called.with.exactly(1, 2, 'three', 4, 5);
       noop.should.not.have.been.called();
     });
   });


### PR DESCRIPTION
Reusing the `l` variable caused an error with multiple listeners and 3+ arguments.  Added a test that fails in this case and a fix.
